### PR TITLE
Enabling the removal of the AVM prefix

### DIFF
--- a/src/org/aion/interfaces/db/Repository.java
+++ b/src/org/aion/interfaces/db/Repository.java
@@ -96,4 +96,6 @@ public interface Repository<AS, BSB> extends RepositoryQuery<AS> {
 
     /** Performs batch transactions remove. */
     void removeTxBatch(Set<byte[]> pendingTx, boolean isPool);
+
+    byte getVMUsed(Address contract);
 }

--- a/src/org/aion/interfaces/vm/VirtualMachineSpecs.java
+++ b/src/org/aion/interfaces/vm/VirtualMachineSpecs.java
@@ -1,7 +1,0 @@
-package org.aion.interfaces.vm;
-
-public final class VirtualMachineSpecs {
-
-    public static final byte AVM_CREATE_CODE = 0x0f;
-    public static final byte FVM_CREATE_CODE = 0x01;
-}

--- a/src/org/aion/interfaces/vm/VirtualMachineSpecs.java
+++ b/src/org/aion/interfaces/vm/VirtualMachineSpecs.java
@@ -3,6 +3,5 @@ package org.aion.interfaces.vm;
 public final class VirtualMachineSpecs {
 
     public static final byte AVM_CREATE_CODE = 0x0f;
-    public static final byte FVM_ALLOWED_TX_TYPE = 0x00;
-    public static final byte FVM_DEFAULT_TX_TYPE = 0x01;
+    public static final byte FVM_CREATE_CODE = 0x01;
 }


### PR DESCRIPTION
To remove the specific AVM contract prefix the kernel interfaces need to query the repository for the VM used at contract deployment.

These changes correspond to aionnetwork/aion#851